### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/Typora/Typora.download.recipe
+++ b/Typora/Typora.download.recipe
@@ -44,7 +44,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/%NAME%.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>anchor apple generic and identifier "abnerworks.Typora" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.11635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9HWK5273G4")</string>
 			</dict>
 		</dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.