### PR TITLE
Update Regex to Download x86 dmg file

### DIFF
--- a/Franz/Franz.download.recipe
+++ b/Franz/Franz.download.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>asset_regex</key>
-				<string>%NAME%-[\S]+\.dmg</string>
+				<string>.*\d+\.\d+\.\d+\.dmg$</string>
 				<key>github_repo</key>
 				<string>meetfranz/franz</string>
 				<key>include_prereleases</key>


### PR DESCRIPTION
Franz5 on git have 2 multiple dmg files for x86 and arm ... 
The old regex just fetched the first machine one which right now ist the ARM installer.
The new Regex fetches the intel installer again.

The also is a new download recipe für the ARM version here: https://github.com/autopkg/jannheider-recipes/tree/main/Franz