### PR TITLE
Update PDF Expert.download.recipe

### DIFF
--- a/PDF Expert/PDF Expert.download.recipe
+++ b/PDF Expert/PDF Expert.download.recipe
@@ -16,48 +16,43 @@
     <key>Process</key>
     <array>
         <dict>
-        <key>Processor</key>
-        <string>SparkleUpdateInfoProvider</string>
-        <key>Arguments</key>
-        <dict>
-          <key>appcast_url</key>
-          <string>https://d1ke680phyeohy.cloudfront.net/release/appcast.xml</string>
-        </dict>
-      </dict>
-        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.zip</string>
+                <key>url</key>
+                <string>https://downloads.pdfexpert.org/pem3/release/PDFExpert.zip</string>
+            </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%url%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>purge_destination</key>
-                <true/>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unzip</string>
-            </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
             <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
+            <string>Unarchiver</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/unzip/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/PDF Expert.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.readdle.PDFExpert-Mac" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3L68KQB4HG")</string>
             </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
         </dict>
     </array>
 </dict>

--- a/PDF Expert/PDF Expert.pkg.recipe
+++ b/PDF Expert/PDF Expert.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/unzip/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/PDF Expert.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/PDF Expert.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -48,7 +48,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/PDF Expert.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Hi, @faumac 

This PR switches to using a static URL as the sparkle feed looks to be abandoned.

```
curl https://d1ke680phyeohy.cloudfront.net/release/appcast.xml
<?xml version="1.0"?>
<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
  <channel>
    <title>PDF Expert Changelog</title>
    <language>en</language>

    <item>
      <title>Version 465</title>
      <sparkle:releaseNotesLink>https://downloads.pdfexpert.com/release/developer-id-update/changelog.html</sparkle:releaseNotesLink>
      <pubDate>Fri, 03 Apr 2020 17:10:16 +0300</pubDate>
      <enclosure url="https://downloads.pdfexpert.com/release/10_10/PDFExpert.zip" sparkle:version="465" sparkle:shortVersionString="2.2.20" length="40305523" type="application/octet-stream"/>
      <sparkle:minimumSystemVersion>10.10</sparkle:minimumSystemVersion>
      <sparkle:maximumSystemVersion>10.10.999</sparkle:maximumSystemVersion>
    </item>

    <item>
      <title>Version 600</title>
      <sparkle:releaseNotesLink>https://downloads.pdfexpert.com/release/developer-id-update/changelog.html</sparkle:releaseNotesLink>
      <pubDate>Fri, 03 Apr 2020 17:10:16 +0300</pubDate>
      <enclosure url="https://downloads.pdfexpert.com/release/10_11/PDFExpert.zip" sparkle:version="600" sparkle:shortVersionString="2.4.15" length="54199859" type="application/octet-stream"/>
      <sparkle:minimumSystemVersion>10.11</sparkle:minimumSystemVersion>
      <sparkle:maximumSystemVersion>10.11.999</sparkle:maximumSystemVersion>
    </item>
    
    <item>
      <title>Version 676</title>
      <sparkle:releaseNotesLink>https://downloads.pdfexpert.com/release/developer-id-update/changelog.html</sparkle:releaseNotesLink>
      <pubDate>Fri, 03 Apr 2020 17:10:16 +0300</pubDate>
      <enclosure url="https://downloads.pdfexpert.com/release/10_12/PDFExpert.zip" sparkle:version="676" sparkle:shortVersionString="2.5.4" length="44570654" type="application/octet-stream"/>
      <sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>
      <sparkle:maximumSystemVersion>10.12.999</sparkle:maximumSystemVersion>
    </item>

    <item>
      <title>Version 764</title>
      <sparkle:releaseNotesLink>https://downloads.pdfexpert.com/release/developer-id-update/changelog.html</sparkle:releaseNotesLink>
      <pubDate>Fri, 8 Jul 2022 12:11:18 +0300</pubDate>
      <enclosure url="https://downloads.pdfexpert.com/versions/764/PDFExpert.zip" sparkle:version="764" sparkle:shortVersionString="2.5.22" length="60851095" type="application/octet-stream"/>
      <sparkle:minimumSystemVersion>10.13</sparkle:minimumSystemVersion>
    </item>
  </channel>
</rss>
```

Running `strings /Users/**/Downloads/PDF\ Expert\ Installer.app/Contents/MacOS/PDF\ Expert\ Installer` I was able to piece together what looks to be a static download url of `https://downloads.pdfexpert.org/pem3/release/PDFExpert.zip` which grabs the latest release of `3.4`

Output from a successful -v run:
```
autopkg run -vv /Users/**/Documents/GitHub/AutoPkg\ Repos/faumac-recipes/PDF\ Expert/PDF\ Expert.download.recipe 
Processing /Users/**/Documents/GitHub/AutoPkg Repos/faumac-recipes/PDF Expert/PDF Expert.download.recipe...
WARNING: /Users/**/Documents/GitHub/AutoPkg Repos/faumac-recipes/PDF Expert/PDF Expert.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'PDF Expert.zip',
           'url': 'https://downloads.pdfexpert.org/pem3/release/PDFExpert.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 24 Aug 2023 10:28:45 GMT
URLDownloader: Storing new ETag header: "f346922432e89e059bafe4d4358b99f6-13"
URLDownloader: Downloaded /Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/downloads/PDF Expert.zip
{'Output': {'download_changed': True,
            'etag': '"f346922432e89e059bafe4d4358b99f6-13"',
            'last_modified': 'Thu, 24 Aug 2023 10:28:45 GMT',
            'pathname': '/Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/downloads/PDF '
                        'Expert.zip',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/downloads/PDF '
                                                                        'Expert.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/downloads/PDF '
                           'Expert.zip',
           'destination_path': '/Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/PDF '
                               'Expert',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename PDF Expert.zip
Unarchiver: Unarchived /Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/downloads/PDF Expert.zip to /Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/PDF Expert
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/PDF '
                         'Expert/PDF Expert.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.readdle.PDFExpert-Mac" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "3L68KQB4HG")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/PDF Expert/PDF Expert.app: valid on disk
CodeSignatureVerifier: /Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/PDF Expert/PDF Expert.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/PDF Expert/PDF Expert.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/receipts/PDF Expert.download-receipt-20230825-101649.plist

The following new items were downloaded:
    Download Path                                                                                           
    -------------                                                                                           
    /Users/**/Library/AutoPkg/Cache/com.github.faumac.download.pdfexpert/downloads/PDF Expert.zip
```

