### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Affinity Designer 2/Affinity Designer 2.pkg.recipe
+++ b/Affinity Designer 2/Affinity Designer 2.pkg.recipe
@@ -172,8 +172,6 @@ exit 0</string>
                     <string>%version%</string>
                     <key>scripts</key>
                     <string>%RECIPE_CACHE_DIR%/scripts</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Affinity Designer/Affinity Designer.pkg.recipe
+++ b/Affinity Designer/Affinity Designer.pkg.recipe
@@ -132,8 +132,6 @@ exit 0</string>
                     <string>%version%</string>
                     <key>scripts</key>
                     <string>%RECIPE_CACHE_DIR%/scripts</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Affinity Photo 2/Affinity Photo 2.pkg.recipe
+++ b/Affinity Photo 2/Affinity Photo 2.pkg.recipe
@@ -172,8 +172,6 @@ exit 0</string>
                     <string>%version%</string>
                     <key>scripts</key>
                     <string>%RECIPE_CACHE_DIR%/scripts</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Affinity Photo/Affinity Photo.pkg.recipe
+++ b/Affinity Photo/Affinity Photo.pkg.recipe
@@ -132,8 +132,6 @@ exit 0</string>
                     <string>%version%</string>
                     <key>scripts</key>
                     <string>%RECIPE_CACHE_DIR%/scripts</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Affinity Publisher 2/Affinity Publisher 2.pkg.recipe
+++ b/Affinity Publisher 2/Affinity Publisher 2.pkg.recipe
@@ -172,8 +172,6 @@ exit 0</string>
                     <string>%version%</string>
                     <key>scripts</key>
                     <string>%RECIPE_CACHE_DIR%/scripts</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Affinity Publisher/Affinity Publisher.pkg.recipe
+++ b/Affinity Publisher/Affinity Publisher.pkg.recipe
@@ -132,8 +132,6 @@ exit 0</string>
                     <string>%version%</string>
                     <key>scripts</key>
                     <string>%RECIPE_CACHE_DIR%/scripts</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/FFmpeg/FFmpeg.pkg.recipe
+++ b/FFmpeg/FFmpeg.pkg.recipe
@@ -85,8 +85,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.github.faumac.autopkg.ffmpeg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Franz/Franz.pkg.recipe
+++ b/Franz/Franz.pkg.recipe
@@ -78,8 +78,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.meetfranz.franz</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Network Share Mounter/Network Share Mounter.pkg.recipe
+++ b/Network Share Mounter/Network Share Mounter.pkg.recipe
@@ -66,8 +66,6 @@
                     <string>de.fau.rrze.networkShareMounter</string>
                     <key>version</key>
                     <string>%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Sourcetree/Sourcetree.pkg.recipe
+++ b/Sourcetree/Sourcetree.pkg.recipe
@@ -68,8 +68,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.torusknot.SourceTreeNotMAS</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/darktable/darktable.pkg.recipe
+++ b/darktable/darktable.pkg.recipe
@@ -75,8 +75,6 @@
                         <string>org.darktable</string>
                         <key>version</key>
                         <string>%version%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._