### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Affinity Designer 2/Affinity Designer 2.download.recipe
+++ b/Affinity Designer 2/Affinity Designer 2.download.recipe
@@ -35,6 +35,10 @@
       </dict>
       <dict>
         <key>Processor</key>
+        <string>EndOfCheckPhase</string>
+      </dict>
+      <dict>
+        <key>Processor</key>
         <string>Unarchiver</string>
         <key>Arguments</key>
         <dict>
@@ -43,10 +47,6 @@
             <key>destination_path</key>
           <string>%RECIPE_CACHE_DIR%/downloads</string>
         </dict>
-      </dict>
-      <dict>
-        <key>Processor</key>
-        <string>EndOfCheckPhase</string>
       </dict>
       <dict>
       <key>Processor</key>

--- a/Affinity Designer/Affinity Designer.download.recipe
+++ b/Affinity Designer/Affinity Designer.download.recipe
@@ -30,6 +30,10 @@
       </dict>
       <dict>
         <key>Processor</key>
+        <string>EndOfCheckPhase</string>
+      </dict>
+      <dict>
+        <key>Processor</key>
         <string>Unarchiver</string>
         <key>Arguments</key>
         <dict>
@@ -38,10 +42,6 @@
             <key>destination_path</key>
           <string>%RECIPE_CACHE_DIR%/downloads</string>
         </dict>
-      </dict>
-      <dict>
-        <key>Processor</key>
-        <string>EndOfCheckPhase</string>
       </dict>
       <dict>
      <key>Processor</key>

--- a/Affinity Photo 2/Affinity Photo 2.download.recipe
+++ b/Affinity Photo 2/Affinity Photo 2.download.recipe
@@ -35,6 +35,10 @@
       </dict>
       <dict>
         <key>Processor</key>
+        <string>EndOfCheckPhase</string>
+      </dict>
+      <dict>
+        <key>Processor</key>
         <string>Unarchiver</string>
         <key>Arguments</key>
         <dict>
@@ -43,10 +47,6 @@
             <key>destination_path</key>
           <string>%RECIPE_CACHE_DIR%/downloads</string>
         </dict>
-      </dict>
-      <dict>
-        <key>Processor</key>
-        <string>EndOfCheckPhase</string>
       </dict>
       <dict>
       <key>Processor</key>

--- a/Affinity Photo/Affinity Photo.download.recipe
+++ b/Affinity Photo/Affinity Photo.download.recipe
@@ -30,6 +30,10 @@
       </dict>
       <dict>
         <key>Processor</key>
+        <string>EndOfCheckPhase</string>
+      </dict>
+      <dict>
+        <key>Processor</key>
         <string>Unarchiver</string>
         <key>Arguments</key>
         <dict>
@@ -38,10 +42,6 @@
           <key>destination_path</key>
           <string>%RECIPE_CACHE_DIR%/downloads</string>
         </dict>
-      </dict>
-      <dict>
-        <key>Processor</key>
-        <string>EndOfCheckPhase</string>
       </dict>
       <dict>
       <key>Processor</key>

--- a/Affinity Publisher 2/Affinity Publisher 2.download.recipe
+++ b/Affinity Publisher 2/Affinity Publisher 2.download.recipe
@@ -35,6 +35,10 @@
       </dict>
       <dict>
         <key>Processor</key>
+        <string>EndOfCheckPhase</string>
+      </dict>
+      <dict>
+        <key>Processor</key>
         <string>Unarchiver</string>
         <key>Arguments</key>
         <dict>
@@ -43,10 +47,6 @@
             <key>destination_path</key>
           <string>%RECIPE_CACHE_DIR%/downloads</string>
         </dict>
-      </dict>
-      <dict>
-        <key>Processor</key>
-        <string>EndOfCheckPhase</string>
       </dict>
       <dict>
       <key>Processor</key>

--- a/Affinity Publisher/Affinity Publisher.download.recipe
+++ b/Affinity Publisher/Affinity Publisher.download.recipe
@@ -30,6 +30,10 @@
       </dict>
       <dict>
         <key>Processor</key>
+        <string>EndOfCheckPhase</string>
+      </dict>
+      <dict>
+        <key>Processor</key>
         <string>Unarchiver</string>
         <key>Arguments</key>
         <dict>
@@ -38,10 +42,6 @@
           <key>destination_path</key>
           <string>%RECIPE_CACHE_DIR%/downloads</string>
         </dict>
-      </dict>
-      <dict>
-        <key>Processor</key>
-        <string>EndOfCheckPhase</string>
       </dict>
       <dict>
      <key>Processor</key>

--- a/PDF Expert/PDF Expert.download.recipe
+++ b/PDF Expert/PDF Expert.download.recipe
@@ -35,6 +35,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -43,10 +47,6 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/unzip</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.